### PR TITLE
dokument adapter endret til å ta dataklasse dokument

### DIFF
--- a/src/main/kotlin/no/nav/dagpenger/journalføring/arena/JournalføringArena.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/arena/JournalføringArena.kt
@@ -44,11 +44,15 @@ class JournalføringArena(
     override val HTTP_PORT: Int = configuration.application.httpPort
     override val healthChecks: List<HealthCheck> = listOf(arenaClient as HealthCheck)
 
-    val dokumentAdapter = moshiInstance.adapter<List<String>>(
+    val dokumentAdapter = moshiInstance.adapter<List<Dokument>>(
             Types.newParameterizedType(
                     List::class.java,
-                    String::class.java
+                    Dokument::class.java
             )
+    )
+
+    data class Dokument (
+        val tittel: String
     )
 
     override fun filterPredicates(): List<Predicate<String, Packet>> {
@@ -65,7 +69,7 @@ class JournalføringArena(
         val journalpostId = packet.getStringValue(PacketKeys.JOURNALPOST_ID)
         val registrertDato: String = packet.getStringValue(PacketKeys.DATO_REGISTRERT)
         val dokumentTitler =
-                packet.getObjectValue(PacketKeys.DOKUMENT_TITLER) { dokumentAdapter.fromJsonValue(it)!! }
+                packet.getObjectValue(PacketKeys.DOKUMENT_TITLER) { dokumentAdapter.fromJsonValue(it)!! }.map { it.tittel }
         val enhetId =
             packet.getObjectValue(PacketKeys.BEHANDLENDE_ENHETER) { behandlendeenhetAdapter.fromJsonValue(it)!! }
                 .first().enhetId

--- a/src/main/kotlin/no/nav/dagpenger/journalføring/arena/JsonAdapters.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/arena/JsonAdapters.kt
@@ -1,0 +1,15 @@
+package no.nav.dagpenger.journalføring.arena
+
+import com.squareup.moshi.Types
+import no.nav.dagpenger.events.moshiInstance
+
+val dokumentAdapter = moshiInstance.adapter<List<Dokument>>(
+    Types.newParameterizedType(
+        List::class.java,
+        Dokument::class.java
+    )
+)
+
+data class Dokument (
+    val tittel: String
+)

--- a/src/test/kotlin/no/nav/dagpenger/journalføring/arena/DokumentAdapterTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/journalføring/arena/DokumentAdapterTest.kt
@@ -1,0 +1,29 @@
+package no.nav.dagpenger.journalføring.arena
+
+import com.squareup.moshi.Types
+import io.kotlintest.shouldBe
+import io.kotlintest.shouldNotBe
+import no.nav.dagpenger.events.moshiInstance
+import org.junit.jupiter.api.Test
+
+class DokumentAdapterTest {
+    data class DokumentInfo(val tittel: String, val brevkode: String)
+    @Test
+    fun `Skal greie å konvertere dokumentInfo med flere felter til Dokument med tittel`() {
+        val dokumenter = listOf(DokumentInfo("en", "123"), DokumentInfo("to", "123"))
+        val dokumentInfoAdapter = moshiInstance.adapter<List<DokumentInfo>>(
+            Types.newParameterizedType(
+                List::class.java,
+                DokumentInfo::class.java
+            )
+        )
+
+        val json = dokumentInfoAdapter.toJsonValue(dokumenter)
+
+        val konverterteDokumenter = dokumentAdapter.fromJsonValue(json)
+
+        konverterteDokumenter shouldNotBe null
+        konverterteDokumenter?.first()?.tittel shouldBe "en"
+        konverterteDokumenter?.last()?.tittel shouldBe "to"
+    }
+}

--- a/src/test/kotlin/no/nav/dagpenger/journalføring/arena/DokumentAdapterTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/journalføring/arena/DokumentAdapterTest.kt
@@ -1,26 +1,17 @@
 package no.nav.dagpenger.journalføring.arena
 
-import com.squareup.moshi.Types
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldNotBe
-import no.nav.dagpenger.events.moshiInstance
 import org.junit.jupiter.api.Test
 
 class DokumentAdapterTest {
     data class DokumentInfo(val tittel: String, val brevkode: String)
     @Test
     fun `Skal greie å konvertere dokumentInfo med flere felter til Dokument med tittel`() {
-        val dokumenter = listOf(DokumentInfo("en", "123"), DokumentInfo("to", "123"))
-        val dokumentInfoAdapter = moshiInstance.adapter<List<DokumentInfo>>(
-            Types.newParameterizedType(
-                List::class.java,
-                DokumentInfo::class.java
-            )
-        )
 
-        val json = dokumentInfoAdapter.toJsonValue(dokumenter)
+        val json = """[{"tittel": "en", "brevkode": "123"}, {"tittel": "to"}]""".trimIndent()
 
-        val konverterteDokumenter = dokumentAdapter.fromJsonValue(json)
+        val konverterteDokumenter = dokumentAdapter.fromJson(json)
 
         konverterteDokumenter shouldNotBe null
         konverterteDokumenter?.first()?.tittel shouldBe "en"

--- a/src/test/kotlin/no/nav/dagpenger/journalføring/arena/JournalFøringArenaTopologyTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/journalføring/arena/JournalFøringArenaTopologyTest.kt
@@ -67,7 +67,7 @@ class JournalFøringArenaTopologyTest {
             )
             putValue("naturligIdent", "12345678")
             putValue("journalpostId", "666")
-            putValue("dokumentTitler", listOf("Tittel 1"))
+            putValue("dokumentTitler", listOf(JournalføringArena.Dokument("tittel 1")))
             putValue("datoRegistrert", "2019")
         }
 

--- a/src/test/kotlin/no/nav/dagpenger/journalføring/arena/JournalFøringArenaTopologyTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/journalføring/arena/JournalFøringArenaTopologyTest.kt
@@ -67,7 +67,7 @@ class JournalFøringArenaTopologyTest {
             )
             putValue("naturligIdent", "12345678")
             putValue("journalpostId", "666")
-            putValue("dokumentTitler", listOf(JournalføringArena.Dokument("tittel 1")))
+            putValue("dokumenter", listOf(Dokument("Søknad 1")))
             putValue("datoRegistrert", "2019")
         }
 


### PR DESCRIPTION
dette fordi joark mottak nå legger ut et objekt av typen dokument på pakke
fremfor kun en liste av tittelstrenger

dokumentAdapter deserialiserer nå til en liste av Dokument,
hvor vi kun henter ut dokument.tittel